### PR TITLE
Aryan/updates

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -128,11 +128,11 @@ function Footer() {
                 as="a"
                 _hover={{ fontWeight: "600", cursor: "pointer" }}
                 transition="0.1s"
-                target="_blank"
+                target="_self"
                 href={urls.Hashnomics}
                 opacity="60%"
               >
-                Hashnomics
+                Hashnomics (To be announced)
               </Text>
             </VStack>
           </GridItem>

--- a/consts/urls.js
+++ b/consts/urls.js
@@ -51,8 +51,7 @@ export const urls = {
   Linkedin:
     "https://www.linkedin.com/company/0xhashstack/?originalSubdomain=in",
   Bug_Bounty: "https://blog.hashstack.finance/launching-community-bug-bounty",
-  Hashstack_101:
-    " https://docs.hashstack.finance/zk-testnet-guide/accessing-the-testnet",
+  Hashstack_101: "https://docs.hashstack.finance/testnet-guide/",
   //articles
   article1:
     "https://blog.hashstack.finance/deconstructing-hashstacks-dynamic-interest-algorithm-dial/",


### PR DESCRIPTION
[HASH-496](https://hashstack.atlassian.net/browse/HASH-496)

Description:

There are two links which didn’t work: Hashnomics and Hashstack 101.

![image](https://user-images.githubusercontent.com/86202585/235688997-a6864fca-56ab-4560-ae27-9077100a7a80.png)

Update 

“Hashstack 101” to [V 0.10](https://docs.hashstack.finance/testnet-guide/)

“Hashnomics” to “To be announced“.

![image](https://user-images.githubusercontent.com/86202585/235689341-5f278d92-43f6-438a-a990-8e2454250926.png)

[HASH-496]: https://hashstack.atlassian.net/browse/HASH-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ